### PR TITLE
Post hooks

### DIFF
--- a/engine/Hook.php
+++ b/engine/Hook.php
@@ -1,0 +1,5 @@
+<?php
+abstract class Hook
+{
+    abstract public function doHook(Post $post);
+}

--- a/engine/Updater.php
+++ b/engine/Updater.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(dirname(__FILE__) . '/Post.php');
+require_once(dirname(__FILE__) . '/Hook.php');
 
 class Updater
 {
@@ -315,6 +316,7 @@ class Updater
                 $dir = dirname($expected_fname);
                 if (! file_exists($dir)) mkdir_as_parent_owner($dir, 0755, true);
                 if (file_put_contents_as_dir_owner($expected_fname, $post->normalized_source())) safe_unlink($filename);
+                self::post_hooks($post);
             }
 
             if (! file_exists($filename)) {
@@ -335,6 +337,7 @@ class Updater
                     $dir = dirname($expected_fname);
                     if (! file_exists($dir)) mkdir_as_parent_owner($dir, 0755, true);
                     if (file_put_contents_as_dir_owner($expected_fname, $post->normalized_source())) safe_unlink($filename);
+                    self::post_hooks($post);
                 } else {
                     $post->write_permalink_page(true);
                 }
@@ -344,6 +347,27 @@ class Updater
                 copy($filename, $draft_dest_path . '/' . basename($filename));
             }
         }        
+    }
+    
+    public static function post_hooks($post)
+    {
+        $dir = self::$source_path . '/hooks';
+        if (is_dir($dir)) {
+            if ($dh = opendir($dir)) {
+                while ( ($file = readdir($dh) ) !== false) {
+                    if ($file[0] == '.') continue;
+                    if (substr($file, 0, 5) == 'post_')
+                    {
+                        $fullpath = $dir . '/' . $file;
+                        require($fullpath);
+                        $className = ucfirst(substr($file, 5, strlen($file) - 9));
+                        $hook = new $className;
+                        $hook->doHook($post);
+                    }
+                }
+                closedir($dh);
+            }
+        }
     }
     
     public static function update_pages()
@@ -621,3 +645,4 @@ class Updater
         }
     }
 }
+

--- a/example-hooks/post_dummy.php
+++ b/example-hooks/post_dummy.php
@@ -1,0 +1,8 @@
+<?php
+class Dummy extends Hook
+{
+    public function doHook(Post $post)
+    {
+        error_log('Hooked ' . $post->title);
+    }
+}


### PR DESCRIPTION
Added hook capability to allow external hooks to be created to execute when a post is published. This will allow for things like posting to Facebook or Twitter.

Hooks should be named post_CLASSNAME.php and placed in the $source_path/hooks directory and should extend the Hook class found in engine/Hook.php.  An example hook that does nothing is in the example-hooks directory.
