### PR TITLE
Styles in /templates

### DIFF
--- a/engine/Updater.php
+++ b/engine/Updater.php
@@ -356,6 +356,22 @@ class Updater
             }
         }        
     }
+
+    public static function update_styles()
+    {
+        foreach (self::changed_files_in_directory(self::$source_path . '/templates') as $filename => $info) {
+            $file_info = pathinfo($filename);
+            if ($file_info['extension'] != 'css') continue;
+            
+            error_log("Changed style file: $filename");
+            $uri = substring_after($filename, self::$source_path . '/templates');
+            $dest_filename = self::$dest_path . $uri;
+            $output_path = dirname($dest_filename);
+            if (! file_exists($output_path)) mkdir_as_parent_owner($output_path, 0755, true);
+            copy($filename, $dest_filename);
+            self::$changes_were_written = true;
+        }
+    }
     
     public static function post_hooks($post)
     {
@@ -427,6 +443,7 @@ class Updater
         
         self::update_pages();
         self::update_drafts();
+        self::update_styles();
 
         foreach (self::changed_files_in_directory(self::$source_path . '/media') as $filename => $info) {
             error_log("Changed media file: $filename");


### PR DESCRIPTION
Hi Marco,

I've added an `update_styles()` function (+ call) to `Updater.php` to sync any .css files changes from the  `{SOURCE_PATH}/templates`  to the webroot.

If this is not compatible with your workflow feel free to deny the request. The code is based on how you sync files in the media directory.
