### PR TITLE
Support for drafts created with Windows and OS 9 line-endings

### DIFF
--- a/engine/Post.php
+++ b/engine/Post.php
@@ -64,7 +64,7 @@ class Post
         $this->is_draft = ($is_draft === -1 ? (false !== strpos($source_filename, 'drafts/') || false !== strpos($source_filename, 'pages/')) : $is_draft);
         $this->timestamp = filemtime($source_filename);
 
-        $segments = explode("\n\n", trim(file_get_contents($source_filename)), 2);
+        $segments = preg_split( '/\R\R/',  trim(file_get_contents($source_filename)), 2);
         if (! isset($segments[1])) $segments[1] = '';
 
         if (count($segments) > 1) {


### PR DESCRIPTION
Hi Marco,
When creating drafts, you are splitting paragraphs using `explode( "\n\n",$s)`.

Because of that code when creating text files in a windows environment they are not processed by SecondCrack. This is a fix for that.
