### PR TITLE
Bookmarklet For Embedding Videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ config.php
 cache
 www
 engine/secondcrack-updater.pid
-
+api-www/add-video.zip

--- a/README.markdown
+++ b/README.markdown
@@ -136,7 +136,7 @@ To edit a post, simply edit its file in `posts/`. The updater will notice the ch
 
 # Posting with bookmarklets
 
-Second Crack comes with a pair of convenience bookmarklets, "Draft Link" and "Draft Article", that create draft posts from the current page and any selected text.
+Second Crack comes with convenience bookmarklets—"Draft Link", "Draft Article", and "Draft Video Link"—that create draft posts from the current page and any selected text. "Draft Videos" will embed any Vimeo or YouTube videos.
 
 To enable this, create a second web root on an alternate domain, e.g. `admin.myblog.com`, using the `api-www/` folder as its document root. Then you can navigate to, e.g.:
 

--- a/api-www/add-draft.php
+++ b/api-www/add-draft.php
@@ -24,7 +24,8 @@ if (! isset($_GET['u'])) {
     ?>
     <p>
         <a href="javascript:<?= rawurlencode(str_replace('EXTRA', 'is-link=1', $bookmarklet_code)) ?>">Draft Link</a> &bull;
-        <a href="javascript:<?= rawurlencode(str_replace('EXTRA', '', $bookmarklet_code)) ?>">Draft Article</a>
+        <a href="javascript:<?= rawurlencode(str_replace('EXTRA', '', $bookmarklet_code)) ?>">Draft Article</a>  &bull;
+        <a href="javascript:<?= rawurlencode(str_replace('EXTRA', 'is-video=1', $bookmarklet_code)) ?>">Draft Video Link</a>
     </p>
     
     <p>
@@ -35,11 +36,18 @@ if (! isset($_GET['u'])) {
         Draft article code:<br/>
         <textarea>javascript:<?= h(rawurlencode(str_replace('EXTRA', '', $bookmarklet_code))) ?></textarea>
     </p>
+    <p>
+        Draft video link code:<br/>
+        <textarea>javascript:<?= h(rawurlencode(str_replace('EXTRA', 'is-video=1', $bookmarklet_code))) ?></textarea>
+    </p>
     <?
     exit;
 }
 
 $url = substring_before(normalize_space($_GET['u']), ' ');
+$is_video = isset($_GET['is-video']) && intval($_GET['is-video']);
+$html = get_html($url);
+$video = video_embed($html);
 $title = normalize_space($_GET['t']);
 $selection = trim($_GET['s']);
 $is_link = isset($_GET['is-link']) && intval($_GET['is-link']);
@@ -48,15 +56,53 @@ if (! $slug) $slug = 'draft';
 
 if ($selection) {
     $body = "> " . str_replace("\n", "\n> ", trim($selection)) . "\n\n";
-    if (! $is_link) $body = "[$title]($url):\n\n" . $body;
+    if (! ($is_link or $is_video)) $body = "[$title]($url):\n\n" . $body;
 } else {
     $body = '';
+}
+
+if ($is_video) $body = $video . $body;
+
+// Get the HTML with cURL
+function get_html($url) {
+  $ch = curl_init();
+  $timeout = 5;
+  curl_setopt($ch,CURLOPT_URL,$url);
+  curl_setopt($ch,CURLOPT_RETURNTRANSFER,1);
+  curl_setopt($ch,CURLOPT_CONNECTTIMEOUT,$timeout);
+  $data = curl_exec($ch);
+  curl_close($ch);
+  return $data;
+}
+
+function video_embed($html) {
+	// Regex for parsing HTML
+    $vimeo = array('#player.vimeo.com/video/([0-9]*)#i');
+    $youtube = array('#/embed/([0-9a-z_-]+)#i', '#youtu.be/([0-9a-z_-]+)#i', '#/v/([0-9a-z_-]+)#i', '#v=([0-9a-z_-]+)#i');
+
+    // Perform preg_match on Vimeo regex array
+	for ($i = 0; $i < sizeof($vimeo); $i++) {
+		preg_match($vimeo[$i], $html, $id);
+		if ($id[1] != NULL) {
+			return '<iframe src="http://player.vimeo.com/video/' . $id[1] . '?title=0&amp;byline=0&amp;portrait=0&amp;color=ff0000&amp;fullscreen=1&amp;autoplay=0" frameborder="0"></iframe>';	    	
+	    }		
+	}
+	
+	// Perform preg_match on Youtube regex array
+	for ($i = 0; $i < sizeof($youtube); $i++) {
+    	    preg_match($youtube[$i], $html, $id);
+    	    // Return embed URL with video ID if a match is found
+    	    if ($id[1] != NULL) {
+	        return '<iframe src="http://www.youtube.com/embed/' . $id[1] . '?autohide=1&amp;fs=1&amp;autoplay=0&amp;iv_load_policy=3&amp;rel=0&amp;modestbranding=1&amp;showinfo=0&amp;hd=1" frameborder="0" allowfullscreen></iframe>';	
+    	    }
+	}
+	return NULL;	
 }
 
 $draft_contents = 
     $title . "\n" . 
     str_repeat('=', max(10, min(40, strlen($title)))) . "\n" .
-    ($is_link ? "Link: " . $url . "\n" : '') .
+    (($is_link or $is_video) ? "Link: " . $url . "\n" : '') .
     "publish-not-yet\n" .
     "\n" .
     $body


### PR DESCRIPTION
Hey Marco,

I added a third bookmarklet to your add-drafts.php. As long as the page you're on has a video from YouTube or Vimeo, clicking the "Draft Video Link" bookmarklet will create a draft with the video embedded (along with any selected text). 

All this commit does it add a third bookmarklet. There's no modifications to your existing functionality, just a convenient addition. I think it would be a nice extension. 

You can read more about it on my blog: [http://jayhickey.com/2012/06/17/second-crack-bookmarklet-for-videos](http://jayhickey.com/2012/06/17/second-crack-bookmarklet-for-videos)
